### PR TITLE
Explicitly specify a format provider to use when converting PdfDate t…

### DIFF
--- a/dotNET/pdfclown.lib/src/org/pdfclown/objects/PdfDate.cs
+++ b/dotNET/pdfclown.lib/src/org/pdfclown/objects/PdfDate.cs
@@ -106,7 +106,7 @@ namespace org.pdfclown.objects
     private static string Format(
       DateTime value
       )
-    {return ("D:" + value.ToString(FormatString).Replace(':','\'') + "'");}
+    {return ("D:" + value.ToString(FormatString, new CultureInfo("en-US")).Replace(':','\'') + "'");}
     #endregion
     #endregion
     #endregion


### PR DESCRIPTION
…o a string

Various sources on the internet suggest that CultureInfo.InvariantCulture can be used, but as the read side at https://github.com/BoldonJames/PDFClown/blob/ce5d866466e396c314cdb688af861f93efbd0c26/dotNET/pdfclown.lib/src/org/pdfclown/objects/PdfDate.cs#L97 uses CultureInfo("en-US") it seemed reasonable to be consistent