### PR TITLE
When updating the document identifier, handles dates specially to avo…

### DIFF
--- a/dotNET/pdfclown.lib/src/org/pdfclown/files/FileIdentifier.cs
+++ b/dotNET/pdfclown.lib/src/org/pdfclown/files/FileIdentifier.cs
@@ -58,7 +58,12 @@ namespace org.pdfclown.files
       BinaryWriter buffer,
       object value
       )
-    {buffer.Write(value.ToString());}
+    {
+      if (value is PdfDate pdfDate)
+        buffer.Write(pdfDate.RawValue);
+      else
+        buffer.Write(value.ToString());
+    }
 
     private static PdfArray CreateBaseDataObject(
       )


### PR DESCRIPTION
…id locale problems

A work around for problems with PdfDateTime.ToString() when running on a system with a non-gregorian calendar - e.g.

```
  ----> System.Exception : File identifier digest failed.
  ----> System.ArgumentOutOfRangeException : Specified time is not supported in this calendar. It should be between 04/30/1900 00:00:00 (Gregorian date) and 11/16/2077 23:59:59 (Gregorian date), inclusive.
```

Adding a ToString() override to PdfDateTime seems like a better technical solution, but I don't know enough about the code to say if that might effect other things (it might be called from other places, and being layers of overridden virtual functions make it hard to be sure), so - be directly explicit and just change the identifier code itself, where hashing the binary value of dates shouldn't have a functional difference to hashing the string values.